### PR TITLE
feat: add NotFair (Claude Code skills for SEO, Google Ads & Meta Ads)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Welcome to Awesome AI Tools! This repository curates a list of powerful, efficie
 - **[Taskade](https://taskade.com)**: AI-native workspace platform to build apps, deploy autonomous AI agents, and automate workflows with 100+ integrations - from one prompt.
 - **[Xquik](https://xquik.com/en)**: Developer-facing X automation platform with REST API, webhooks, and MCP support.
 - **[OpenClaw](https://openclaw.ai/)**: Clears your inbox, sends emails, manages your calendar, checks you in for flights. All from WhatsApp, Telegram, or any chat app.
+- **[NotFair](https://github.com/nowork-studio/NotFair)**: Open-source Claude Code skills (~2.9k stars) for SEO, GEO, Google Ads, and Meta Ads. Connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP to automate audits, keyword research, bid management, and ad creative workflows.
 
 ### ChatBot, Summarization, and Note-Taking
 - **[NotebookLM](https://notebooklm.google/)**: A tool by Google that helps users understand and organize their documents through summarization, question-answering, and audio overviews.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Welcome to Awesome AI Tools! This repository curates a list of powerful, efficie
 - **[Taskade](https://taskade.com)**: AI-native workspace platform to build apps, deploy autonomous AI agents, and automate workflows with 100+ integrations - from one prompt.
 - **[Xquik](https://xquik.com/en)**: Developer-facing X automation platform with REST API, webhooks, and MCP support.
 - **[OpenClaw](https://openclaw.ai/)**: Clears your inbox, sends emails, manages your calendar, checks you in for flights. All from WhatsApp, Telegram, or any chat app.
-- **[NotFair](https://github.com/nowork-studio/NotFair)**: Open-source Claude Code skills (~2.9k stars) for SEO, GEO, Google Ads, and Meta Ads. Connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP to automate audits, keyword research, bid management, and ad creative workflows.
+- **[NotFair](https://github.com/nowork-studio/NotFair)**: Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads, powered by the Google Ads, Meta Ads, Search Console, and GA4 MCPs.
 
 ### ChatBot, Summarization, and Note-Taking
 - **[NotebookLM](https://notebooklm.google/)**: A tool by Google that helps users understand and organize their documents through summarization, question-answering, and audio overviews.


### PR DESCRIPTION
Hi, thanks for maintaining this list — it's a great resource!

I'd like to suggest adding **[NotFair](https://github.com/nowork-studio/NotFair)**, an open-source set of Claude Code agent skills for marketing work (~2.9k stars, MIT license). It covers SEO analysis, keyword research, meta tags, schema markup, GEO optimization, Google Ads audits, and Meta Ads management. It connects to live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.

I added it to the **Automation** section since it automates marketing workflows through AI agents — happy to move it to a different section or adjust the wording if you prefer.

Thanks for your time!