### PR TITLE
Add BlynkAI Tudo and Telo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Welcome to Awesome AI Tools! This repository curates a list of powerful, efficie
 - **[Xquik](https://xquik.com/en)**: Developer-facing X automation platform with REST API, webhooks, and MCP support.
 - **[OpenClaw](https://openclaw.ai/)**: Clears your inbox, sends emails, manages your calendar, checks you in for flights. All from WhatsApp, Telegram, or any chat app.
 - **[NotFair](https://github.com/nowork-studio/NotFair)**: Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads, powered by the Google Ads, Meta Ads, Search Console, and GA4 MCPs.
+- **[BlynkAI Tudo](https://blynkai.app/tudo/)**: An AI task manager for iPhone that turns voice notes, screenshots, shared content, and complex goals into organized tasks and subtasks.
 
 ### ChatBot, Summarization, and Note-Taking
 - **[NotebookLM](https://notebooklm.google/)**: A tool by Google that helps users understand and organize their documents through summarization, question-answering, and audio overviews.
@@ -90,6 +91,7 @@ Welcome to Awesome AI Tools! This repository curates a list of powerful, efficie
 ### Other Tools
 - **[Flux](https://www.flux.ai/p)**: An AI-powered EDA tool featuring a Copilot that reviews designs, interprets datasheets, and can even route your board.
 - **[Stability AI](https://stability.ai/)**: Diffusion models for Image, Video, Speech, 3D, and Language.
+- **[BlynkAI Telo](https://blynkai.app/telo/)**: An AI wellness companion for iPhone that uses Apple Health context and user-logged events to help people reflect on readiness, recovery, sleep, and daily body-state trends.
 
 ### Presentation and Design
 - **[Gamma](https://gamma.app)**: AI-powered tool to create presentations quickly.


### PR DESCRIPTION
Adds two BlynkAI iPhone AI apps following the repository format and category structure:

- BlynkAI Tudo under Automation for AI task capture and planning.
- BlynkAI Telo under Other Tools for AI-assisted wellness reflection based on Apple Health context.

This follows up on issue #33, where a pull request was requested.