### PR TITLE
Add Tokens Forge to programming tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Welcome to Awesome AI Tools! This repository curates a list of powerful, efficie
 - **[Cursor](https://www.cursor.com/)**: Integrated advanced AI features directly into the coding environment.
 - **[GitHub Copilot](https://github.com/features/copilot)**: The AI code editor for everyone.
 - **[CoderPlan](https://coderplan.ai)**: LLM API gateway with OpenAI-compatible interface. Pay-per-use access to Claude, GPT, Gemini, and 100+ models. Optimized for Chinese developers.
+- **[Tokens Forge](https://tokens-forge.com/)**: Multi-model AI token platform with OpenAI-compatible API access to GPT, Claude, and Gemini, usage ledgers, starter RMB credit, and an AI trading research assistant.
 - **[Google Antigravity](https://antigravity.google/)**: Google Antigravity is an AI-powered IDE, designed for prioritizing AI agents platform for software development.
 - **[OpenMagic](https://github.com/Kalmuraee/OpenMagic)**: Browser-side AI coding toolbar for live web app edits with context capture and approval-gated diffs.
 - **[Roblox GUI Maker](https://robloxguimaker.dev/)**: AI-assisted planner for Roblox Studio ScreenGui layouts, HUDs, menus, and Lua UI starter-code ideas.


### PR DESCRIPTION
Adds Tokens Forge to the Programming category as a multi-model AI token platform with OpenAI-compatible API access for GPT, Claude, and Gemini-style models, usage ledgers, starter RMB credit, and an AI trading research assistant.\n\nDisclosure: I am helping promote Tokens Forge for its founder.