### PR TITLE
Add cv.cm/v to Video Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Welcome to Awesome AI Tools! This repository curates a list of powerful, efficie
 - **[cPB](https://github.com/rezapaki1376/cPB)**: cPB is a method specifically designed to handle the complexities of streaming time series data, effectively addressing the unique challenges associated with this context.
 
 ### Video Generation
+- **[cv.cm/v](https://cv.cm/v)**: Queue-free, full-power Seedance 2.0 text-to-video and image-to-video studio with image generation, a node-graph canvas, and a REST API; 100 free credits on signup.
 - **[ImagineClip](https://imagineclip.com/)**: AI video generator for social clips, avatar videos, stylized scenes, and shareable visual effects.
 
 ### Writing


### PR DESCRIPTION
Adds **[cv.cm/v](https://cv.cm/v)** to the Video Generation section.

cv.cm/v is a queue-free, full-power **Seedance 2.0** text-to-video / image-to-video studio with image generation, a node-graph canvas, and a REST API; 100 free credits on signup. One bullet added, matching the existing `- **[Name](url)**: Description` format.