### PR TITLE
Add ToolMagpie (live-verified AI agent directory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Welcome to Awesome AI Tools! This repository curates a list of powerful, efficie
 
 ### 📜 Other Sections  
 - [📖 Contribution Guidelines](#contribution-guidelines)  
+- [ToolMagpie](https://toolmagpie.com) - Live-verified directory of AI agents (customer service, sales, coding, MCP servers, automation) that auto-flags dead tools, with side-by-side comparisons and honest pricing.
 - [🐞 Issue Reporting](#issue-reporting)  
 
 ## Categories


### PR DESCRIPTION
Adds [ToolMagpie](https://toolmagpie.com) — a live-verified directory of AI agents (customer service, sales, coding, no-code builders, MCP servers, automation) that auto-flags dead tools with weekly link checks, plus side-by-side comparisons and honest pricing. Thanks for maintaining this list!