### PR TITLE
Add YingTu to image tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Welcome to Awesome AI Tools! This repository curates a list of powerful, efficie
 - **[Aurcue](https://www.aurcue.com)**: AI personal aesthetic assistant that turns one uploaded photo into practical guidance for color analysis, outfits, hairstyles, and glasses.
 - **[HairWow](https://www.gohairwow.com)**: AI hairstyle try-on for previewing haircuts, hair colors, beards, and salon or barber references from one photo.
 - **[ImagineClip](https://imagineclip.com)**: AI video generator for avatar clips, stylized scenes, and social-ready videos from prompts, images, and effects.
+- **[YingTu](https://yingtu.ai/en)**: Browser playground for testing AI image and video API routes, prompts, reference inputs, task status, and downloads before integration.
 
 ### Image Processing and Computer Vision
 - **[Vehicel Tracking](https://github.com/milad-goudarzi/Object-tracking)**: Track and count vehicles in a video using advanced Deep Learning techniques.


### PR DESCRIPTION
## Tool information

- **Website name:** YingTu
- **URL:** https://yingtu.ai/en
- **Category:** Image Generation and Enhancement
- **Short description:** Browser playground for testing AI image and video API routes, prompts, reference inputs, task status, and downloads before integration.

## Verification

- The public URL is accessible.
- YingTu and yingtu.ai were not present in the current README.
- The entry follows the repository's required Markdown format.
- The diff is limited to one README line: 1 addition and 0 deletions.

Submitting on behalf of the YingTu project. This contribution was prepared with OpenAI Codex assistance. Opening the playground is free; generation requires a valid API key and follows active account and route rules. No affiliate links or unrelated changes are included.