### PR TITLE
Add AISO Tools to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Welcome to Awesome AI Tools! This repository curates a list of powerful, efficie
 - **[Flux](https://www.flux.ai/p)**: An AI-powered EDA tool featuring a Copilot that reviews designs, interprets datasheets, and can even route your board.
 - **[Stability AI](https://stability.ai/)**: Diffusion models for Image, Video, Speech, 3D, and Language.
 - **[BlynkAI Telo](https://blynkai.app/telo/)**: An AI wellness companion for iPhone that uses Apple Health context and user-logged events to help people reflect on readiness, recovery, sleep, and daily body-state trends.
+- **[AISO Tools](https://aisotools.com)**: Checks whether ChatGPT, Perplexity and other AI assistants actually recommend a given product, and reports the gaps that keep it from being cited.
 
 ### Presentation and Design
 - **[Gamma](https://gamma.app)**: AI-powered tool to create presentations quickly.


### PR DESCRIPTION
Adds one entry under **Other Tools**.

- **[AISO Tools](https://aisotools.com)** — checks whether ChatGPT, Perplexity and other AI assistants actually recommend a given product, and reports the gaps that keep it from being cited.

Free to use, no signup for the audit. Placed in *Other Tools* rather than a generator category since it measures AI output rather than producing it. Follows the README's documented entry format (`- **[Name](url)**: description.`).