### PR TITLE
Add Agent QA to Programming

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Welcome to Awesome AI Tools! This repository curates a list of powerful, efficie
   
 ### Programming
 - **[Cursor](https://www.cursor.com/)**: Integrated advanced AI features directly into the coding environment.
+- **[Agent QA](https://github.com/vostride/agent-qa)**: Source-available application QA harness for natural-language web and mobile tests, with a CLI, dashboard, MCP server, persistent execution memory, and self-healing workflows.
 - **[Better Agent](https://github.com/ofekron/better-agent)**: Workspace for running persistent Claude, Codex, and Gemini coding-agent sessions with delegation, parallel forks, approvals, and restart recovery.
 - **[GitHub Copilot](https://github.com/features/copilot)**: The AI code editor for everyone.
 - **[CoderPlan](https://coderplan.ai)**: LLM API gateway with OpenAI-compatible interface. Pay-per-use access to Claude, GPT, Gemini, and 100+ models. Optimized for Chinese developers.


### PR DESCRIPTION
## Summary

Adds Agent QA to the Programming section.

The entry describes it as a source-available application-QA harness for natural-language web and mobile tests and links to the canonical repository. It does not describe Agent QA as an IDE or as OSI open source.

## Verification

- confirmed the entry follows the repository's documented Markdown format
- confirmed Agent QA appears exactly once in `README.md`
- `git diff --check`

## Disclosure

I am affiliated with Agent QA and am submitting the project itself.

Agent QA's current release is source-available under FSL-1.1-ALv2 and converts to Apache-2.0 after two years; it should not be classified as OSI open source today. The package is free to install, but model, browser, or device providers configured by a user may charge separately for usage.
