### PR TITLE
docs: add SandBase to programming tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Welcome to Awesome AI Tools! This repository curates a list of powerful, efficie
 - **[GitHub Copilot](https://github.com/features/copilot)**: The AI code editor for everyone.
 - **[CoderPlan](https://coderplan.ai)**: LLM API gateway with OpenAI-compatible interface. Pay-per-use access to Claude, GPT, Gemini, and 100+ models. Optimized for Chinese developers.
 - **[Tokens Forge](https://tokens-forge.com/)**: Multi-model AI token platform with OpenAI-compatible API access to GPT, Claude, and Gemini, usage ledgers, starter RMB credit, and an AI trading research assistant.
+- **[SandBase](https://sandbase.ai/)**: Open-source CLI and local MCP bridge for discovering and running 2,000+ AI models through one API.
 - **[Google Antigravity](https://antigravity.google/)**: Google Antigravity is an AI-powered IDE, designed for prioritizing AI agents platform for software development.
 - **[OpenMagic](https://github.com/Kalmuraee/OpenMagic)**: Browser-side AI coding toolbar for live web app edits with context capture and approval-gated diffs.
 - **[Roblox GUI Maker](https://robloxguimaker.dev/)**: AI-assisted planner for Roblox Studio ScreenGui layouts, HUDs, menus, and Lua UI starter-code ideas.


### PR DESCRIPTION
Adds SandBase to the Programming section using the repository's contribution format.

- Product: https://sandbase.ai/
- Canonical open-source repository: https://github.com/sandbaseai/cli
- Local MCP bridge and CLI for discovering and running 2,000+ AI models through one API

Disclosure: I contribute to sandbaseai/cli. The description is concise and factual for maintainer review.