### PR TITLE
Add LLM Pulse to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Welcome to Awesome AI Tools! This repository curates a list of powerful, efficie
 - **[Stability AI](https://stability.ai/)**: Diffusion models for Image, Video, Speech, 3D, and Language.
 - **[BlynkAI Telo](https://blynkai.app/telo/)**: An AI wellness companion for iPhone that uses Apple Health context and user-logged events to help people reflect on readiness, recovery, sleep, and daily body-state trends.
 - **[AISO Tools](https://aisotools.com)**: Checks whether ChatGPT, Perplexity and other AI assistants actually recommend a given product, and reports the gaps that keep it from being cited.
+- **[LLM Pulse](https://llmpulse.ai/)**: Monitors brand mentions, citations, sentiment, and competitor share of voice across AI search engines.
 - **[StudyArena](https://studyarena.com)**: Helps students compare three anonymous AI answers, vote for the most useful response, and reveal the models afterward.
 
 ### Presentation and Design


### PR DESCRIPTION
## Summary

Adds one entry for LLM Pulse under **Other Tools**, next to the existing AI-search visibility tool.

- Website: https://llmpulse.ai/
- Category: Other Tools
- Description: Monitors brand mentions, citations, sentiment, and competitor share of voice across AI search engines.

The entry follows the documented `- **[Tool Name](url)**: description.` format and links directly to the canonical product page.

Disclosure: I am a co-founder of LLM Pulse.