### PR TITLE
Add Milo to ChatBot, Summarization, and Note-Taking

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Welcome to Awesome AI Tools! This repository curates a list of powerful, efficie
 - **[Evernote](https://evernote.com)**: Organizes notes, tasks, and supports clipping from websites.
 - **[Gemini](https://gemini.google.com/)**: A coding agent capable of fixing bugs, editing and validating code, and managing tasks under a developer's supervision.
 - **[Grok](https://grok.com/)**: Grok is a free AI assistant designed by xAI to maximize truth and objectivity. Grok offers real-time search, image generation, trend analysis, and more.
+- **[Milo](https://milo.seemplifyai.com/)**: A browser voice chatbot with a gesturing Three.js robot and local or optional ChatGPT replies. Free for personal, noncommercial use.
 
 ### Cybersecurity and Hacking
 - **WormGPT**: Blackhat alternative to GPT models, designed specifically for malicious activities.


### PR DESCRIPTION
Adds [Milo](https://github.com/michaelegbo/milo) to **ChatBot, Summarization, and Note-Taking**.

Provides an interactive voice-and-avatar chatbot experience in the existing chatbot category.

Demo: https://milo.seemplifyai.com/

Milo uses on-device Whisper transcription and local Qwen replies. Hosted speech sends output text through Milo to a voice provider, with local Kokoro as fallback; optional ChatGPT sends messages and context through Milo to OpenAI. Source is available under PolyForm Noncommercial 1.0.0, not an OSI open-source license.

Affiliation: this is a submission by the Milo project owner, prepared with AI assistance. No sponsorship or paid placement is requested.

Validation: reviewed the destination section and contribution instructions, checked for duplicates, and verified the source and demo links. One listing addition; no unrelated changes.